### PR TITLE
Avoid key-value dependency for docset link generation

### DIFF
--- a/sphinx_tsn_theme/versions.html
+++ b/sphinx_tsn_theme/versions.html
@@ -8,7 +8,7 @@
     <div class="rst-other-versions">
       {%- for name, config in theme_docsets.items() %}
       <div class="rst-other-version {{ name }}">
-        <a href="{{ pathto('', 1) }}../{{ name }}/{{ config[1] }}.html">{{ config[0] }}</a>
+        <a href="{{ pathto('', 1) }}../{{ config[1] }}.html">{{ config[0] }}</a>
       </div>
       {%- endfor %}
     </div>


### PR DESCRIPTION
In preperation to support more external docset entries with the same context as decoded by the list key the configuration value config[1] now have to provide the document root that may have an equal prefix, ex.:

before:
```
  {{"name": bridle,
    "config": {"Bridle", "index"}},
   {"name": bridle-api,
    "config": {"Bridle API", "doxygen/html/index"}}}
```
becomes:
```
  <a href=".../bridle/index.html">Bridle</a>
  <a href=".../bridle-api/doxygen/html/index.html">Bridle API</a>
```
  ... but that's incorrect and have to be as ...

now:
```
  {{"name": bridle,
    "config": {"Bridle", "bridle/index"}},
   {"name": bridle-api,
    "config": {"Bridle API", "bridle/doxygen/html/index"}}}
```
becomes:
```
  <a href=".../bridle/index.html">Bridle</a>
  <a href=".../bridle/doxygen/html/index.html">Bridle API</a>
```