### PR TITLE
Extends figures default alignment on center

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_namespace_packages
 import re
 import os.path
 
@@ -22,7 +22,7 @@ setup(
     author_email="info@tiac-systems.net",
     description="TiaC Systems Network (TSN) theme for Sphinx",
     long_description=open("README.rst", encoding="utf-8").read(),
-    packages=["sphinx_tsn_theme"],
+    packages=find_namespace_packages(),
     package_data={
         "sphinx_tsn_theme": [
             "theme.conf",

--- a/sphinx_tsn_theme/static/css/tiac.css
+++ b/sphinx_tsn_theme/static/css/tiac.css
@@ -63,7 +63,12 @@
   border-width: 0;
 }
 
-/* Center-align images */
+/* align figures on center per default */
+figure.align-default {
+  text-align: center;
+}
+
+/* align figures on center per default (backward compatibility) */
 div.figure {
   text-align: center;
 }


### PR DESCRIPTION
Newer Sphinx versions will render figures within the HTML element figure and not anymore inside a div.figure block. This PR will support this too.