### PR TITLE
Bump sphinx-rtd-theme dependency to version >=1.0,<3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sphinx_rtd_theme>=1.0,<1.4
+sphinx_rtd_theme>=1.0,<3.0


### PR DESCRIPTION
Since `sphinx-rtd-theme` is now on version `2.0.0`, and that seems to have introduced no relevant breaking changes, the dependency can probably be bumped.

To test this I built the bridle docs with `sphinx-tsn-theme 2023.12.1` against `sphinx-rtd-theme 2.0.0`, which works perfectly fine.