### PR TITLE
Bring back the simple version output from RTD v2

### DIFF
--- a/sphinx_tsn_theme/__init__.py
+++ b/sphinx_tsn_theme/__init__.py
@@ -16,7 +16,7 @@ except ImportError:
     from logging import getLogger
 
 
-__version__ = "2024.10.1"
+__version__ = "2024.11.0"
 __version_full__ = __version__
 
 logger = getLogger(__name__)

--- a/sphinx_tsn_theme/layout.html
+++ b/sphinx_tsn_theme/layout.html
@@ -8,3 +8,24 @@
     <link rel="shortcut icon" href="{{ pathto('_static/images/favicon.ico', 1) }}"/>
   {% endif %}
 {% endblock %}
+{% block sidebartitle %}
+  {# The TSN theme is not yet ready to use the new version and language
+     selector from the RTD theme v3. This would need to be replaced
+     exactly in this 'sidebartitle' block by the old simple version
+     output from the RTD Theme v2. Unfortunately, the RTD theme does
+     not yet offer a separate block for replacing it with a customized
+     version and language selector. Since this must be inserted exactly
+     before the include of the 'searchbox' and in the RTD Theme it is
+     protected by the environment variable 'READTHEDOCS' and the
+     configuration options 'theme_version_selector' and
+     'theme_language_selector' (we will never be allowed to set this
+     constellation to True), the TSN Theme will use the following trick:
+
+         This 'sidebartitle' block remains unchanged, but the 'searchbox'
+         template in the TSN theme is extended right at the beginning by
+         the old simple version output from the RTD theme v2.
+
+     Here we leave only this explanation!
+  #}
+  {{ super() }}
+{% endblock %}

--- a/sphinx_tsn_theme/searchbox.html
+++ b/sphinx_tsn_theme/searchbox.html
@@ -1,4 +1,17 @@
-{%- if builder != 'singlehtml' %}
+{# Bring back the old simple version output from the RTD Theme v2. #}
+{# See 'layout.html', block.super() for 'sidebartitle' for more details. #}
+{%- if theme_display_version %}
+  {%- set nav_version = version %}
+  {%- if READTHEDOCS and current_version %}
+    {%- set nav_version = current_version %}
+  {%- endif %}
+  {%- if nav_version %}
+    <div class="version">
+      {{ nav_version }}
+    </div>
+  {%- endif %}
+{%- endif %}
+{%- if 'singlehtml' not in builder %}
 <div id="searchbox" role="search">
   <div class="searchformwrapper">
     <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">


### PR DESCRIPTION
The TSN theme is not yet ready to use the new version and language selector from the RTD theme v3. Thus we add it as "porting" to the TSN theme again.